### PR TITLE
Add a function to return an ID as well as a name

### DIFF
--- a/source/main.cpp
+++ b/source/main.cpp
@@ -11,11 +11,11 @@ GMOD_MODULE_OPEN( )
 {
 	LUA->CreateTable( );
 
-	LUA->PushString( "luaerror 1.4.1" );
+	LUA->PushString( "luaerror 1.5.0" );
 	LUA->SetField( -2, "Version" );
 
 	// version num follows LuaJIT style, xxyyzz
-	LUA->PushNumber( 10401 );
+	LUA->PushNumber( 10500 );
 	LUA->SetField( -2, "VersionNum" );
 
 #if defined LUAERROR_SERVER


### PR DESCRIPTION
I realised that I needed the ID of the addon more than I needed the name of it (since names can change), but I didn't want to keep impinging on your good will/free time.
I hope you're ok with doing it like this. Another option would be to populate and return a table with all of the info in it, but I didn't want the overhead and thought that it would be a bit out of scope for this module.

This won't compile properly without danielga/sourcesdk-minimal#8.

Thanks!