### PR TITLE
Maybe fix linux build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ addons:
   apt:
     packages:
       - linux-libc-dev:i386
+      - g++-multilib
 install:
   - export MODULE_NAME="luaerror"
   - export REPOSITORY_DIR="$TRAVIS_BUILD_DIR"


### PR DESCRIPTION
When I compiled locally I had to install `libc6-dev-i386` but you've already got something that looks a bit like this, so [the second answer on Stack Overflow](https://askubuntu.com/a/590832) suggests installing `g++-multilib`, which I see you removed in 2f240a95d88ed3e0f6f60102332131122bd213cf.