### PR TITLE
Solve a crash when changing levels

### DIFF
--- a/source/server/server.cpp
+++ b/source/server/server.cpp
@@ -123,6 +123,7 @@ void Initialize( GarrysMod::Lua::ILuaBase *LUA )
 
 void Deinitialize( GarrysMod::Lua::ILuaBase * )
 {
+	HandleClientLuaError_detour.Disable( );
 	HandleClientLuaError_detour.Destroy( );
 }
 

--- a/source/shared/shared.cpp
+++ b/source/shared/shared.cpp
@@ -428,6 +428,7 @@ void Deinitialize( GarrysMod::Lua::ILuaBase * )
 {
 	ResetRuntime( );
 	ResetCompiletime( );
+	AdvancedLuaErrorReporter_detour.Disable( );
 	AdvancedLuaErrorReporter_detour.Destroy( );
 }
 


### PR DESCRIPTION
The hooks remained after shutdown as disable wasn't called (for some reason disable needs to be called as destroy doesn't really work?)
This caused it to enter an infinite loop after a map change, which would crash the server, as when it called the original function using GetTrampoline it called the old detour hook, which then called the new detour hook, forming a loop?